### PR TITLE
Fbxify tool

### DIFF
--- a/CustomMap/Assets/Editor/FBXifyMeshes.cs
+++ b/CustomMap/Assets/Editor/FBXifyMeshes.cs
@@ -1,0 +1,186 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace CustomMap.Editor
+{
+    public static class FBXifyMeshes
+    {
+        private const string MENU_ROOT = "Tools/FBXify Meshes/";
+        private const string FBX_OUTPUT_ROOT = "FBX";
+        
+        [MenuItem(MENU_ROOT + "Process Selected Prefabs")]
+        public static void ProcessSelectedPrefabs()
+        {
+            var selectedPrefabs = GetSelectedPrefabs();
+            
+            if (selectedPrefabs.Count == 0)
+            {
+                EditorUtility.DisplayDialog("FBXify Meshes", 
+                    "No prefabs selected. Please select one or more prefabs in the Project window.", 
+                    "OK");
+                return;
+            }
+            
+            if (!EditorUtility.DisplayDialog("FBXify Meshes", 
+                $"Process {selectedPrefabs.Count} selected prefab(s)?", 
+                "Process", "Cancel"))
+            {
+                return;
+            }
+            
+            ProcessPrefabs(selectedPrefabs);
+        }
+        
+        [MenuItem(MENU_ROOT + "Process All Prefabs in Folder")]
+        public static void ProcessAllPrefabsInFolder()
+        {
+            string folderPath = EditorUtility.OpenFolderPanel("Select Folder with Prefabs", "Assets", "");
+            
+            if (string.IsNullOrEmpty(folderPath))
+                return;
+                
+            // Convert absolute path to relative path
+            if (folderPath.StartsWith(Application.dataPath))
+            {
+                folderPath = "Assets" + folderPath.Substring(Application.dataPath.Length);
+            }
+            
+            var prefabGuids = AssetDatabase.FindAssets("t:Prefab", new[] { folderPath });
+            var prefabPaths = prefabGuids.Select(guid => AssetDatabase.GUIDToAssetPath(guid)).ToList();
+            
+            if (prefabPaths.Count == 0)
+            {
+                EditorUtility.DisplayDialog("FBXify Meshes", 
+                    "No prefabs found in the selected folder.", 
+                    "OK");
+                return;
+            }
+            
+            if (!EditorUtility.DisplayDialog("FBXify Meshes", 
+                $"Process {prefabPaths.Count} prefab(s) in folder?", 
+                "Process", "Cancel"))
+            {
+                return;
+            }
+            
+            ProcessPrefabs(prefabPaths);
+        }
+        
+        [MenuItem("Assets/FBXify This Prefab", false, 1000)]
+        public static void FBXifyContextMenu()
+        {
+            ProcessSelectedPrefabs();
+        }
+        
+        [MenuItem("Assets/FBXify This Prefab", true)]
+        public static bool FBXifyContextMenuValidation()
+        {
+            return GetSelectedPrefabs().Count > 0;
+        }
+        
+        private static List<string> GetSelectedPrefabs()
+        {
+            var prefabs = new List<string>();
+            
+            foreach (var obj in Selection.objects)
+            {
+                string path = AssetDatabase.GetAssetPath(obj);
+                if (!string.IsNullOrEmpty(path) && path.EndsWith(".prefab"))
+                {
+                    prefabs.Add(path);
+                }
+            }
+            
+            return prefabs;
+        }
+        
+        private static void ProcessPrefabs(List<string> prefabPaths)
+        {
+            int processedCount = 0;
+            int failedCount = 0;
+            var failedPrefabs = new List<string>();
+            
+            try
+            {
+                // Don't batch asset editing for FBX import to work properly
+                // AssetDatabase.StartAssetEditing();
+                
+                for (int i = 0; i < prefabPaths.Count; i++)
+                {
+                    string prefabPath = prefabPaths[i];
+                    string prefabName = Path.GetFileNameWithoutExtension(prefabPath);
+                    
+                    float progress = (float)i / prefabPaths.Count;
+                    if (EditorUtility.DisplayCancelableProgressBar("FBXify Meshes", 
+                        $"Processing {prefabName} ({i + 1}/{prefabPaths.Count})", 
+                        progress))
+                    {
+                        break;
+                    }
+                    
+                    try
+                    {
+                        if (FBXifyMeshesProcessor.ProcessPrefab(prefabPath))
+                        {
+                            processedCount++;
+                            Debug.Log($"[FBXify] Successfully processed: {prefabName}");
+                        }
+                        else
+                        {
+                            failedCount++;
+                            failedPrefabs.Add(prefabName);
+                            Debug.LogWarning($"[FBXify] Failed to process: {prefabName}");
+                        }
+                    }
+                    catch (System.Exception e)
+                    {
+                        failedCount++;
+                        failedPrefabs.Add(prefabName);
+                        Debug.LogError($"[FBXify] Error processing {prefabName}: {e.Message}");
+                    }
+                }
+            }
+            finally
+            {
+                // AssetDatabase.StopAssetEditing();
+                AssetDatabase.Refresh();
+                EditorUtility.ClearProgressBar();
+            }
+            
+            // Show results
+            string message = $"Processed {processedCount} prefab(s) successfully.";
+            if (failedCount > 0)
+            {
+                message += $"\n{failedCount} prefab(s) failed:";
+                foreach (var failed in failedPrefabs)
+                {
+                    message += $"\n  • {failed}";
+                }
+            }
+            
+            EditorUtility.DisplayDialog("FBXify Meshes Complete", message, "OK");
+        }
+        
+        public static string GetFBXOutputPath(string prefabName)
+        {
+            // Keep FBX files inside Assets folder so Unity can import them
+            string fbxFolder = Path.Combine(Application.dataPath, FBX_OUTPUT_ROOT, prefabName);
+            
+            if (!Directory.Exists(fbxFolder))
+            {
+                Directory.CreateDirectory(fbxFolder);
+            }
+            
+            return Path.Combine(fbxFolder, $"{prefabName}.fbx");
+        }
+        
+        public static string GetFBXAssetPath(string prefabName)
+        {
+            // Asset path relative to project root
+            return Path.Combine("Assets", FBX_OUTPUT_ROOT, prefabName, $"{prefabName}.fbx");
+        }
+    }
+}

--- a/CustomMap/Assets/Editor/FBXifyMeshes.cs
+++ b/CustomMap/Assets/Editor/FBXifyMeshes.cs
@@ -40,6 +40,44 @@ namespace CustomMap.Editor
             ProcessPrefabs(selectedPrefabs);
         }
         
+        [MenuItem(MENU_ROOT + "Process Selected GameObjects")]
+        public static void ProcessSelectedGameObjects()
+        {
+            var selectedGameObjects = Selection.gameObjects;
+            
+            if (selectedGameObjects.Length == 0)
+            {
+                EditorUtility.DisplayDialog("FBXify Meshes", 
+                    "No GameObjects selected. Please select one or more GameObjects in the Hierarchy window.", 
+                    "OK");
+                return;
+            }
+            
+            // Count total MeshFilters to process
+            int totalMeshFilters = 0;
+            foreach (var go in selectedGameObjects)
+            {
+                totalMeshFilters += go.GetComponentsInChildren<MeshFilter>(true).Length;
+            }
+            
+            if (totalMeshFilters == 0)
+            {
+                EditorUtility.DisplayDialog("FBXify Meshes", 
+                    "No MeshFilters found in the selected GameObjects or their children.", 
+                    "OK");
+                return;
+            }
+            
+            if (!EditorUtility.DisplayDialog("FBXify Meshes", 
+                $"Process {selectedGameObjects.Length} GameObject(s) containing {totalMeshFilters} MeshFilter(s)?", 
+                "Process", "Cancel"))
+            {
+                return;
+            }
+            
+            ProcessGameObjects(selectedGameObjects);
+        }
+        
         [MenuItem(MENU_ROOT + "Process All Prefabs in Folder")]
         public static void ProcessAllPrefabsInFolder()
         {
@@ -85,6 +123,18 @@ namespace CustomMap.Editor
         public static bool FBXifyContextMenuValidation()
         {
             return GetSelectedPrefabs().Count > 0;
+        }
+        
+        [MenuItem("GameObject/FBXify Selected", false, 0)]
+        public static void FBXifyGameObjectContextMenu()
+        {
+            ProcessSelectedGameObjects();
+        }
+        
+        [MenuItem("GameObject/FBXify Selected", true)]
+        public static bool FBXifyGameObjectContextMenuValidation()
+        {
+            return Selection.gameObjects.Length > 0;
         }
         
         private static List<string> GetSelectedPrefabs()
@@ -165,6 +215,78 @@ namespace CustomMap.Editor
             
             EditorUtility.DisplayDialog("FBXify Meshes Complete", message, "OK");
         }
+        
+        private static void ProcessGameObjects(GameObject[] gameObjects)
+        {
+            int processedCount = 0;
+            int failedCount = 0;
+            var failedObjects = new List<string>();
+            
+            try
+            {
+                for (int i = 0; i < gameObjects.Length; i++)
+                {
+                    GameObject go = gameObjects[i];
+                    string rootName = go.name;
+                    
+                    float progress = (float)i / gameObjects.Length;
+                    if (EditorUtility.DisplayCancelableProgressBar("FBXify Meshes", 
+                        $"Processing {rootName} ({i + 1}/{gameObjects.Length})", 
+                        progress))
+                    {
+                        break;
+                    }
+                    
+                    try
+                    {
+                        if (FBXifyMeshesProcessor.ProcessGameObject(go))
+                        {
+                            processedCount++;
+                            Log($"Successfully processed: {rootName}");
+                        }
+                        else
+                        {
+                            failedCount++;
+                            failedObjects.Add(rootName);
+                            LogWarning($"Failed to process: {rootName}");
+                        }
+                    }
+                    catch (System.Exception e)
+                    {
+                        failedCount++;
+                        failedObjects.Add(rootName);
+                        LogError($"Error processing {rootName}: {e.Message}");
+                    }
+                }
+            }
+            finally
+            {
+                AssetDatabase.Refresh();
+                EditorUtility.ClearProgressBar();
+                
+                // Mark the scene as dirty so it can be saved
+                if (processedCount > 0)
+                {
+                    UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(
+                        UnityEditor.SceneManagement.EditorSceneManager.GetActiveScene()
+                    );
+                }
+            }
+            
+            // Show results
+            string message = $"Processed {processedCount} GameObject(s) successfully.";
+            if (failedCount > 0)
+            {
+                message += $"\n{failedCount} GameObject(s) failed:";
+                foreach (var failed in failedObjects)
+                {
+                    message += $"\n  • {failed}";
+                }
+            }
+            
+            EditorUtility.DisplayDialog("FBXify Meshes Complete", message, "OK");
+        }
+        
         public static string GetIndividualFBXOutputPath(string prefabName, string gameObjectName)
         {
             // Keep FBX files inside Assets folder so Unity can import them

--- a/CustomMap/Assets/Editor/FBXifyMeshes.cs
+++ b/CustomMap/Assets/Editor/FBXifyMeshes.cs
@@ -105,19 +105,6 @@ namespace CustomMap.Editor
             return false;
         }
         
-        [MenuItem(MENU_ROOT + "Process All Prefabs in Folder", true)]
-        public static bool ProcessAllPrefabsInFolderValidation()
-        {
-            // Check if a folder is selected
-            foreach (var obj in Selection.objects)
-            {
-                string path = AssetDatabase.GetAssetPath(obj);
-                if (!string.IsNullOrEmpty(path) && AssetDatabase.IsValidFolder(path))
-                    return true;
-            }
-            return false;
-        }
-        
         [MenuItem(MENU_ROOT + "Process All Prefabs in Folder", false)]
         public static void ProcessAllPrefabsInFolder()
         {
@@ -133,7 +120,6 @@ namespace CustomMap.Editor
                 }
             }
 
-            // Shouldn't happen since we have the validation
             string folderPath = EditorUtility.OpenFolderPanel("Select Folder with Prefabs", defaultPath, "");
             
             if (string.IsNullOrEmpty(folderPath))

--- a/CustomMap/Assets/Editor/FBXifyMeshes.cs
+++ b/CustomMap/Assets/Editor/FBXifyMeshes.cs
@@ -9,7 +9,13 @@ namespace CustomMap.Editor
     public static class FBXifyMeshes
     {
         private const string MENU_ROOT = "Tools/FBXify Meshes/";
-        private const string FBX_OUTPUT_ROOT = "FBX";
+        private const string FBX_OUTPUT_ROOT = "FBXify";
+        private const string LOG_PREFIX = "[FBXify]";
+        
+        // Simple logging helpers
+        internal static void Log(string message) => Debug.Log($"{LOG_PREFIX} {message}");
+        internal static void LogWarning(string message) => Debug.LogWarning($"{LOG_PREFIX} {message}");
+        internal static void LogError(string message) => Debug.LogError($"{LOG_PREFIX} {message}");
         
         [MenuItem(MENU_ROOT + "Process Selected Prefabs")]
         public static void ProcessSelectedPrefabs()
@@ -105,9 +111,6 @@ namespace CustomMap.Editor
             
             try
             {
-                // Don't batch asset editing for FBX import to work properly
-                // AssetDatabase.StartAssetEditing();
-                
                 for (int i = 0; i < prefabPaths.Count; i++)
                 {
                     string prefabPath = prefabPaths[i];
@@ -126,26 +129,25 @@ namespace CustomMap.Editor
                         if (FBXifyMeshesProcessor.ProcessPrefab(prefabPath))
                         {
                             processedCount++;
-                            Debug.Log($"[FBXify] Successfully processed: {prefabName}");
+                            Log($"Successfully processed: {prefabName}");
                         }
                         else
                         {
                             failedCount++;
                             failedPrefabs.Add(prefabName);
-                            Debug.LogWarning($"[FBXify] Failed to process: {prefabName}");
+                            LogWarning($"Failed to process: {prefabName}");
                         }
                     }
                     catch (System.Exception e)
                     {
                         failedCount++;
                         failedPrefabs.Add(prefabName);
-                        Debug.LogError($"[FBXify] Error processing {prefabName}: {e.Message}");
+                        LogError($"Error processing {prefabName}: {e.Message}");
                     }
                 }
             }
             finally
             {
-                // AssetDatabase.StopAssetEditing();
                 AssetDatabase.Refresh();
                 EditorUtility.ClearProgressBar();
             }
@@ -163,8 +165,7 @@ namespace CustomMap.Editor
             
             EditorUtility.DisplayDialog("FBXify Meshes Complete", message, "OK");
         }
-        
-        public static string GetFBXOutputPath(string prefabName)
+        public static string GetIndividualFBXOutputPath(string prefabName, string gameObjectName)
         {
             // Keep FBX files inside Assets folder so Unity can import them
             string fbxFolder = Path.Combine(Application.dataPath, FBX_OUTPUT_ROOT, prefabName);
@@ -174,13 +175,13 @@ namespace CustomMap.Editor
                 Directory.CreateDirectory(fbxFolder);
             }
             
-            return Path.Combine(fbxFolder, $"{prefabName}.fbx");
+            return Path.Combine(fbxFolder, $"{gameObjectName}.fbx");
         }
         
-        public static string GetFBXAssetPath(string prefabName)
+        public static string GetIndividualFBXAssetPath(string prefabName, string gameObjectName)
         {
             // Asset path relative to project root
-            return Path.Combine("Assets", FBX_OUTPUT_ROOT, prefabName, $"{prefabName}.fbx");
+            return Path.Combine("Assets", FBX_OUTPUT_ROOT, prefabName, $"{gameObjectName}.fbx");
         }
     }
 }

--- a/CustomMap/Assets/Editor/FBXifyMeshes.cs
+++ b/CustomMap/Assets/Editor/FBXifyMeshes.cs
@@ -8,23 +8,25 @@ namespace CustomMap.Editor
 {
     public static class FBXifyMeshes
     {
-        private const string MENU_ROOT = "Tools/FBXify Meshes/";
-        private const string FBX_OUTPUT_ROOT = "FBXify";
-        private const string LOG_PREFIX = "[FBXify]";
+        public const string TOOL_NAME = "FBXify";
+        public const string TOOL_DISPLAY_NAME = TOOL_NAME + " Meshes";
+        private const string MENU_ROOT = "Gatekeeper/" + TOOL_DISPLAY_NAME + "/";
+        private const string FBX_OUTPUT_ROOT = TOOL_NAME;
+        private const string LOG_PREFIX = "[" + TOOL_NAME + "]";
         
         // Simple logging helpers
         internal static void Log(string message) => Debug.Log($"{LOG_PREFIX} {message}");
         internal static void LogWarning(string message) => Debug.LogWarning($"{LOG_PREFIX} {message}");
         internal static void LogError(string message) => Debug.LogError($"{LOG_PREFIX} {message}");
         
-        [MenuItem(MENU_ROOT + "Process Selected Prefabs")]
+        [MenuItem(MENU_ROOT + "Process Selected Prefabs", false)]
         public static void ProcessSelectedPrefabs()
         {
             var selectedPrefabs = GetSelectedPrefabs();
             
             if (selectedPrefabs.Count == 0)
             {
-                EditorUtility.DisplayDialog("FBXify Meshes", 
+                EditorUtility.DisplayDialog(TOOL_DISPLAY_NAME, 
                     "No prefabs selected. Please select one or more prefabs in the Project window.", 
                     "OK");
                 return;
@@ -40,14 +42,20 @@ namespace CustomMap.Editor
             ProcessPrefabs(selectedPrefabs);
         }
         
-        [MenuItem(MENU_ROOT + "Process Selected GameObjects")]
+        [MenuItem(MENU_ROOT + "Process Selected Prefabs", true)]
+        public static bool ProcessSelectedPrefabsValidation()
+        {
+            return GetSelectedPrefabs().Count > 0;
+        }
+        
+        [MenuItem(MENU_ROOT + "Process Selected GameObject(s)", false)]
         public static void ProcessSelectedGameObjects()
         {
             var selectedGameObjects = Selection.gameObjects;
             
             if (selectedGameObjects.Length == 0)
             {
-                EditorUtility.DisplayDialog("FBXify Meshes", 
+                EditorUtility.DisplayDialog(TOOL_DISPLAY_NAME, 
                     "No GameObjects selected. Please select one or more GameObjects in the Hierarchy window.", 
                     "OK");
                 return;
@@ -62,7 +70,7 @@ namespace CustomMap.Editor
             
             if (totalMeshFilters == 0)
             {
-                EditorUtility.DisplayDialog("FBXify Meshes", 
+                EditorUtility.DisplayDialog(TOOL_DISPLAY_NAME, 
                     "No MeshFilters found in the selected GameObjects or their children.", 
                     "OK");
                 return;
@@ -78,10 +86,52 @@ namespace CustomMap.Editor
             ProcessGameObjects(selectedGameObjects);
         }
         
-        [MenuItem(MENU_ROOT + "Process All Prefabs in Folder")]
+        [MenuItem(MENU_ROOT + "Process Selected GameObject(s)", true)]
+        public static bool ProcessSelectedGameObjectsValidation()
+        {
+            // Only enable if we have scene GameObjects selected (not project assets)
+            if (Selection.gameObjects.Length == 0)
+                return false;
+            
+            // Check that at least one selected object is a scene object (not a prefab asset)
+            foreach (var go in Selection.gameObjects)
+            {
+                if (go.scene.IsValid())
+                    return true;
+            }
+            
+            return false;
+        }
+        
+        [MenuItem(MENU_ROOT + "Process All Prefabs in Folder", true)]
+        public static bool ProcessAllPrefabsInFolderValidation()
+        {
+            // Check if a folder is selected
+            foreach (var obj in Selection.objects)
+            {
+                string path = AssetDatabase.GetAssetPath(obj);
+                if (!string.IsNullOrEmpty(path) && AssetDatabase.IsValidFolder(path))
+                    return true;
+            }
+            return false;
+        }
+        
+        [MenuItem(MENU_ROOT + "Process All Prefabs in Folder", false)]
         public static void ProcessAllPrefabsInFolder()
         {
-            string folderPath = EditorUtility.OpenFolderPanel("Select Folder with Prefabs", "Assets", "");
+            // Get the selected folder path as default for the dialog
+            string defaultPath = "Assets";
+            foreach (var obj in Selection.objects)
+            {
+                string path = AssetDatabase.GetAssetPath(obj);
+                if (!string.IsNullOrEmpty(path) && AssetDatabase.IsValidFolder(path))
+                {
+                    defaultPath = path;
+                    break;
+                }
+            }
+            
+            string folderPath = EditorUtility.OpenFolderPanel("Select Folder with Prefabs", defaultPath, "");
             
             if (string.IsNullOrEmpty(folderPath))
                 return;
@@ -97,7 +147,7 @@ namespace CustomMap.Editor
             
             if (prefabPaths.Count == 0)
             {
-                EditorUtility.DisplayDialog("FBXify Meshes", 
+                EditorUtility.DisplayDialog(TOOL_DISPLAY_NAME, 
                     "No prefabs found in the selected folder.", 
                     "OK");
                 return;
@@ -111,30 +161,6 @@ namespace CustomMap.Editor
             }
             
             ProcessPrefabs(prefabPaths);
-        }
-        
-        [MenuItem("Assets/FBXify This Prefab", false, 1000)]
-        public static void FBXifyContextMenu()
-        {
-            ProcessSelectedPrefabs();
-        }
-        
-        [MenuItem("Assets/FBXify This Prefab", true)]
-        public static bool FBXifyContextMenuValidation()
-        {
-            return GetSelectedPrefabs().Count > 0;
-        }
-        
-        [MenuItem("GameObject/FBXify Selected", false, 0)]
-        public static void FBXifyGameObjectContextMenu()
-        {
-            ProcessSelectedGameObjects();
-        }
-        
-        [MenuItem("GameObject/FBXify Selected", true)]
-        public static bool FBXifyGameObjectContextMenuValidation()
-        {
-            return Selection.gameObjects.Length > 0;
         }
         
         private static List<string> GetSelectedPrefabs()
@@ -213,7 +239,7 @@ namespace CustomMap.Editor
                 }
             }
             
-            EditorUtility.DisplayDialog("FBXify Meshes Complete", message, "OK");
+            EditorUtility.DisplayDialog(TOOL_DISPLAY_NAME + " Complete", message, "OK");
         }
         
         private static void ProcessGameObjects(GameObject[] gameObjects)
@@ -284,7 +310,7 @@ namespace CustomMap.Editor
                 }
             }
             
-            EditorUtility.DisplayDialog("FBXify Meshes Complete", message, "OK");
+            EditorUtility.DisplayDialog(TOOL_DISPLAY_NAME + " Complete", message, "OK");
         }
         
         public static string GetIndividualFBXOutputPath(string prefabName, string gameObjectName)

--- a/CustomMap/Assets/Editor/FBXifyMeshes.cs
+++ b/CustomMap/Assets/Editor/FBXifyMeshes.cs
@@ -26,6 +26,7 @@ namespace CustomMap.Editor
             
             if (selectedPrefabs.Count == 0)
             {
+                // Shouldn't happen since we have the validation
                 EditorUtility.DisplayDialog(TOOL_DISPLAY_NAME, 
                     "No prefabs selected. Please select one or more prefabs in the Project window.", 
                     "OK");
@@ -52,11 +53,12 @@ namespace CustomMap.Editor
         public static void ProcessSelectedGameObjects()
         {
             var selectedGameObjects = Selection.gameObjects;
-            
+
+            // Shouldn't happen since we have the validation
             if (selectedGameObjects.Length == 0)
             {
-                EditorUtility.DisplayDialog(TOOL_DISPLAY_NAME, 
-                    "No GameObjects selected. Please select one or more GameObjects in the Hierarchy window.", 
+                EditorUtility.DisplayDialog(TOOL_DISPLAY_NAME,
+                    "No GameObjects selected. Please select one or more GameObjects in the Hierarchy window.",
                     "OK");
                 return;
             }
@@ -130,7 +132,8 @@ namespace CustomMap.Editor
                     break;
                 }
             }
-            
+
+            // Shouldn't happen since we have the validation
             string folderPath = EditorUtility.OpenFolderPanel("Select Folder with Prefabs", defaultPath, "");
             
             if (string.IsNullOrEmpty(folderPath))

--- a/CustomMap/Assets/Editor/FBXifyMeshes.cs
+++ b/CustomMap/Assets/Editor/FBXifyMeshes.cs
@@ -19,7 +19,7 @@ namespace CustomMap.Editor
         internal static void LogWarning(string message) => Debug.LogWarning($"{LOG_PREFIX} {message}");
         internal static void LogError(string message) => Debug.LogError($"{LOG_PREFIX} {message}");
         
-        [MenuItem(MENU_ROOT + "Process Selected Prefabs", false)]
+        [MenuItem(MENU_ROOT + "Process Selected Prefab(s)", false)]
         public static void ProcessSelectedPrefabs()
         {
             var selectedPrefabs = GetSelectedPrefabs();
@@ -33,7 +33,7 @@ namespace CustomMap.Editor
                 return;
             }
             
-            if (!EditorUtility.DisplayDialog("FBXify Meshes", 
+            if (!EditorUtility.DisplayDialog(TOOL_DISPLAY_NAME, 
                 $"Process {selectedPrefabs.Count} selected prefab(s)?", 
                 "Process", "Cancel"))
             {
@@ -43,7 +43,7 @@ namespace CustomMap.Editor
             ProcessPrefabs(selectedPrefabs);
         }
         
-        [MenuItem(MENU_ROOT + "Process Selected Prefabs", true)]
+        [MenuItem(MENU_ROOT + "Process Selected Prefab(s)", true)]
         public static bool ProcessSelectedPrefabsValidation()
         {
             return GetSelectedPrefabs().Count > 0;
@@ -78,7 +78,7 @@ namespace CustomMap.Editor
                 return;
             }
             
-            if (!EditorUtility.DisplayDialog("FBXify Meshes", 
+            if (!EditorUtility.DisplayDialog(TOOL_DISPLAY_NAME, 
                 $"Process {selectedGameObjects.Length} GameObject(s) containing {totalMeshFilters} MeshFilter(s)?", 
                 "Process", "Cancel"))
             {
@@ -142,7 +142,7 @@ namespace CustomMap.Editor
                 return;
             }
             
-            if (!EditorUtility.DisplayDialog("FBXify Meshes", 
+            if (!EditorUtility.DisplayDialog(TOOL_DISPLAY_NAME, 
                 $"Process {prefabPaths.Count} prefab(s) in folder?", 
                 "Process", "Cancel"))
             {
@@ -182,7 +182,7 @@ namespace CustomMap.Editor
                     string prefabName = Path.GetFileNameWithoutExtension(prefabPath);
                     
                     float progress = (float)i / prefabPaths.Count;
-                    if (EditorUtility.DisplayCancelableProgressBar("FBXify Meshes", 
+                    if (EditorUtility.DisplayCancelableProgressBar(TOOL_DISPLAY_NAME, 
                         $"Processing {prefabName} ({i + 1}/{prefabPaths.Count})", 
                         progress))
                     {
@@ -245,7 +245,7 @@ namespace CustomMap.Editor
                     string rootName = go.name;
                     
                     float progress = (float)i / gameObjects.Length;
-                    if (EditorUtility.DisplayCancelableProgressBar("FBXify Meshes", 
+                    if (EditorUtility.DisplayCancelableProgressBar(TOOL_DISPLAY_NAME, 
                         $"Processing {rootName} ({i + 1}/{gameObjects.Length})", 
                         progress))
                     {

--- a/CustomMap/Assets/Editor/FBXifyMeshes.cs.meta
+++ b/CustomMap/Assets/Editor/FBXifyMeshes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f628c219d81774264a6955c3b3e8bff7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CustomMap/Assets/Editor/FBXifyMeshesProcessor.cs
+++ b/CustomMap/Assets/Editor/FBXifyMeshesProcessor.cs
@@ -151,5 +151,150 @@ namespace CustomMap.Editor
             Log($"Updated {updatedCount}/{meshFilters.Length} mesh references");
             return updatedCount > 0;
         }
+        
+        public static bool ProcessGameObject(GameObject gameObject)
+        {
+            if (gameObject == null)
+            {
+                LogError("GameObject is null");
+                return false;
+            }
+            
+            string rootName = gameObject.name;
+            
+            // Find all MeshFilters in the GameObject and its children
+            MeshFilter[] meshFilters = gameObject.GetComponentsInChildren<MeshFilter>(true);
+            if (meshFilters.Length == 0)
+            {
+                LogWarning($"No MeshFilters found in GameObject: {rootName}");
+                return false;
+            }
+            
+            Log($"Found {meshFilters.Length} MeshFilters in {rootName}");
+            
+            // Use "SceneObjects" as the folder for non-prefab objects
+            string folderName = $"SceneObjects_{rootName}";
+            
+            // Export each GameObject with a MeshFilter as a separate FBX
+            int exportedCount = 0;
+            foreach (var meshFilter in meshFilters)
+            {
+                if (meshFilter.sharedMesh == null)
+                {
+                    LogWarning($"Skipping {meshFilter.gameObject.name} - no mesh assigned");
+                    continue;
+                }
+                
+                string gameObjectName = meshFilter.gameObject.name;
+                string fbxPath = GetIndividualFBXOutputPath(folderName, gameObjectName);
+                
+                // Export this specific GameObject
+                string exportedPath = ModelExporter.ExportObject(fbxPath, meshFilter.gameObject);
+                if (string.IsNullOrEmpty(exportedPath))
+                {
+                    LogError($"Failed to export GameObject: {gameObjectName}");
+                    continue;
+                }
+                
+                Log($"Exported {gameObjectName} to: {exportedPath}");
+                exportedCount++;
+            }
+            
+            if (exportedCount == 0)
+            {
+                LogError($"No GameObjects were exported from {rootName}");
+                return false;
+            }
+            
+            // Force Unity to import all the FBX files
+            AssetDatabase.Refresh();
+            AssetDatabase.SaveAssets();
+            
+            // Update mesh references to point to the FBX files
+            if (!UpdateSceneGameObjectMeshReferences(meshFilters, folderName))
+            {
+                LogError($"Failed to update mesh references: {rootName}");
+                return false;
+            }
+            
+            Log($"Successfully processed {exportedCount} meshes in {rootName}");
+            return true;
+        }
+        
+        private static bool UpdateSceneGameObjectMeshReferences(MeshFilter[] meshFilters, string folderName)
+        {
+            int updatedCount = 0;
+            
+            foreach (var meshFilter in meshFilters)
+            {
+                if (meshFilter.sharedMesh == null)
+                    continue;
+                    
+                string gameObjectName = meshFilter.gameObject.name;
+                string fbxAssetPath = GetIndividualFBXAssetPath(folderName, gameObjectName);
+                
+                // Check if the FBX file exists
+                if (!File.Exists(Path.Combine(Application.dataPath, "..", fbxAssetPath)))
+                {
+                    LogWarning($"FBX not found for {gameObjectName}, skipping");
+                    continue;
+                }
+                
+                // Load the FBX
+                GameObject fbxObject = AssetDatabase.LoadAssetAtPath<GameObject>(fbxAssetPath);
+                if (fbxObject == null)
+                {
+                    LogWarning($"Failed to load FBX for {gameObjectName}");
+                    continue;
+                }
+                
+                // Get the mesh from the FBX
+                Object[] subAssets = AssetDatabase.LoadAllAssetsAtPath(fbxAssetPath);
+                Mesh fbxMesh = null;
+                
+                Log($"Checking FBX at: {fbxAssetPath}");
+                Log($"Found {subAssets.Length} sub-assets in FBX");
+                
+                foreach (var asset in subAssets)
+                {
+                    if (asset is Mesh mesh)
+                    {
+                        fbxMesh = mesh;
+                        Log($"Found mesh '{mesh.name}' (type: {mesh.GetType().Name}) in {gameObjectName}.fbx");
+                        break;
+                    }
+                    else
+                    {
+                        Log($"  Sub-asset: {asset.name} (type: {asset.GetType().Name})");
+                    }
+                }
+                
+                if (fbxMesh != null)
+                {
+                    // Use Undo for scene objects so changes can be undone
+                    Undo.RecordObject(meshFilter, "FBXify Mesh Reference");
+                    
+                    // Store old mesh for logging
+                    string oldMeshName = meshFilter.sharedMesh != null ? meshFilter.sharedMesh.name : "null";
+                    
+                    // Update the mesh reference
+                    meshFilter.sharedMesh = fbxMesh;
+                    
+                    // Force the change to be registered
+                    EditorUtility.SetDirty(meshFilter);
+                    EditorUtility.SetDirty(meshFilter.gameObject);
+                    
+                    updatedCount++;
+                    Log($"Updated mesh reference: {gameObjectName} from '{oldMeshName}' -> '{fbxMesh.name}'");
+                }
+                else
+                {
+                    LogWarning($"No mesh found in FBX for {gameObjectName}");
+                }
+            }
+            
+            Log($"Updated {updatedCount}/{meshFilters.Length} mesh references");
+            return updatedCount > 0;
+        }
     }
 }

--- a/CustomMap/Assets/Editor/FBXifyMeshesProcessor.cs
+++ b/CustomMap/Assets/Editor/FBXifyMeshesProcessor.cs
@@ -1,9 +1,8 @@
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using UnityEditor;
 using UnityEditor.Formats.Fbx.Exporter;
 using UnityEngine;
+using static CustomMap.Editor.FBXifyMeshes;
 
 namespace CustomMap.Editor
 {
@@ -15,149 +14,77 @@ namespace CustomMap.Editor
             GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
             if (prefab == null)
             {
-                Debug.LogError($"[FBXify] Failed to load prefab: {prefabPath}");
+                LogError($"Failed to load prefab: {prefabPath}");
                 return false;
             }
             
             string prefabName = Path.GetFileNameWithoutExtension(prefabPath);
-            string fbxPath = FBXifyMeshes.GetFBXOutputPath(prefabName);
             
-            // Export to FBX using Unity's FBX Exporter
-            string exportedPath = ModelExporter.ExportObject(fbxPath, prefab);
-            if (string.IsNullOrEmpty(exportedPath))
-            {
-                Debug.LogError($"[FBXify] Failed to export FBX: {prefabName}");
-                return false;
-            }
-            Debug.Log($"[FBXify] Exported FBX to: {exportedPath}");
-            
-            // Import the FBX back into Unity
-            string fbxAssetPath = FBXifyMeshes.GetFBXAssetPath(prefabName);
-            
-            // Force Unity to import the FBX file
-            AssetDatabase.Refresh();
-            AssetDatabase.ImportAsset(fbxAssetPath, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
-            
-            // Wait for import to complete
-            AssetDatabase.SaveAssets();
-            
-            // Update mesh references in the original prefab
-            if (!UpdatePrefabMeshReferences(prefabPath, fbxAssetPath))
-            {
-                Debug.LogError($"[FBXify] Failed to update mesh references: {prefabName}");
-                return false;
-            }
-            
-            return true;
-        }
-        
-        private static bool UpdatePrefabMeshReferences(string prefabPath, string fbxAssetPath)
-        {
-            // Ensure the FBX exists in the asset database
-            if (!File.Exists(Path.Combine(Application.dataPath, "..", fbxAssetPath)))
-            {
-                Debug.LogError($"[FBXify] FBX file does not exist at path: {fbxAssetPath}");
-                return false;
-            }
-            
-            // Load the FBX as a model
-            GameObject fbxModel = AssetDatabase.LoadAssetAtPath<GameObject>(fbxAssetPath);
-            if (fbxModel == null)
-            {
-                Debug.LogError($"[FBXify] Failed to load imported FBX: {fbxAssetPath}. Trying to refresh asset database...");
-                AssetDatabase.Refresh();
-                fbxModel = AssetDatabase.LoadAssetAtPath<GameObject>(fbxAssetPath);
-                
-                if (fbxModel == null)
-                {
-                    Debug.LogError($"[FBXify] Still cannot load FBX after refresh: {fbxAssetPath}");
-                    return false;
-                }
-            }
-            
-            // Get all meshes from the FBX
-            var fbxMeshes = new Dictionary<string, Mesh>();
-            CollectMeshesFromFBX(fbxModel, fbxMeshes, fbxAssetPath);
-            
-            // Load and update the prefab
+            // Load prefab contents for editing
             GameObject prefabRoot = PrefabUtility.LoadPrefabContents(prefabPath);
             if (prefabRoot == null)
             {
-                Debug.LogError($"[FBXify] Failed to load prefab for updating: {prefabPath}");
+                LogError($"Failed to load prefab contents: {prefabPath}");
                 return false;
             }
             
             try
             {
-                // Update all MeshFilter components in the prefab
+                // Find all MeshFilters in the prefab
                 MeshFilter[] meshFilters = prefabRoot.GetComponentsInChildren<MeshFilter>(true);
-                int updatedCount = 0;
-                
-                // First, let's see what meshes are available
-                if (fbxMeshes.Count == 0)
+                if (meshFilters.Length == 0)
                 {
-                    Debug.LogWarning($"[FBXify] No meshes found in FBX file!");
-                }
-                else
-                {
-                    Debug.Log($"[FBXify] Found {fbxMeshes.Count} meshes in FBX: {string.Join(", ", fbxMeshes.Keys)}");
+                    LogWarning($"No MeshFilters found in prefab: {prefabName}");
+                    return false;
                 }
                 
+                Log($"Found {meshFilters.Length} MeshFilters in {prefabName}");
+                
+                // Export each GameObject with a MeshFilter as a separate FBX
+                int exportedCount = 0;
                 foreach (var meshFilter in meshFilters)
                 {
-                    if (meshFilter.sharedMesh != null)
+                    if (meshFilter.sharedMesh == null)
                     {
-                        string originalMeshName = meshFilter.sharedMesh.name;
-                        string gameObjectName = meshFilter.gameObject.name;
-                        
-                        // Unity's FBX Exporter typically uses the GameObject name for the mesh
-                        // Let's try to find a mesh that matches
-                        Mesh fbxMesh = null;
-                        string matchedName = null;
-                        
-                        // First try exact GameObject name match
-                        if (fbxMeshes.TryGetValue(gameObjectName, out fbxMesh))
-                        {
-                            matchedName = gameObjectName;
-                        }
-                        // If there's only one mesh and we have many MeshFilters, they might all share it
-                        else if (fbxMeshes.Count == 1)
-                        {
-                            var singleMesh = fbxMeshes.First();
-                            fbxMesh = singleMesh.Value;
-                            matchedName = singleMesh.Key;
-                            Debug.Log($"[FBXify] Using single mesh '{matchedName}' for GameObject '{gameObjectName}'");
-                        }
-                        // Try to find any mesh that contains the GameObject name
-                        else
-                        {
-                            foreach (var kvp in fbxMeshes)
-                            {
-                                if (kvp.Key.Contains(gameObjectName) || gameObjectName.Contains(kvp.Key))
-                                {
-                                    fbxMesh = kvp.Value;
-                                    matchedName = kvp.Key;
-                                    break;
-                                }
-                            }
-                        }
-                        
-                        if (fbxMesh != null)
-                        {
-                            meshFilter.sharedMesh = fbxMesh;
-                            updatedCount++;
-                            Debug.Log($"[FBXify] Updated: {gameObjectName} -> {matchedName} (mesh ID: {fbxMesh.GetInstanceID()})");
-                        }
-                        else
-                        {
-                            Debug.LogWarning($"[FBXify] No match for: {gameObjectName} (original: {originalMeshName})");
-                        }
+                        LogWarning($"Skipping {meshFilter.gameObject.name} - no mesh assigned");
+                        continue;
                     }
+                    
+                    string gameObjectName = meshFilter.gameObject.name;
+                    string fbxPath = GetIndividualFBXOutputPath(prefabName, gameObjectName);
+                    
+                    // Export this specific GameObject
+                    string exportedPath = ModelExporter.ExportObject(fbxPath, meshFilter.gameObject);
+                    if (string.IsNullOrEmpty(exportedPath))
+                    {
+                        LogError($"Failed to export GameObject: {gameObjectName}");
+                        continue;
+                    }
+                    
+                    Log($"Exported {gameObjectName} to: {exportedPath}");
+                    exportedCount++;
+                }
+                
+                if (exportedCount == 0)
+                {
+                    LogError($"No GameObjects were exported from {prefabName}");
+                    return false;
+                }
+                
+                // Force Unity to import all the FBX files
+                AssetDatabase.Refresh();
+                AssetDatabase.SaveAssets();
+                
+                // Update mesh references to point to the FBX files
+                if (!UpdatePrefabMeshReferences(prefabRoot, prefabName, meshFilters))
+                {
+                    LogError($"Failed to update mesh references: {prefabName}");
+                    return false;
                 }
                 
                 // Save the updated prefab
                 PrefabUtility.SaveAsPrefabAsset(prefabRoot, prefabPath);
-                Debug.Log($"[FBXify] Updated {updatedCount} mesh references in prefab: {Path.GetFileNameWithoutExtension(prefabPath)}");
+                Log($"Successfully processed {exportedCount} meshes in {prefabName}");
                 
                 return true;
             }
@@ -167,38 +94,62 @@ namespace CustomMap.Editor
             }
         }
         
-        private static void CollectMeshesFromFBX(GameObject fbxObject, Dictionary<string, Mesh> meshDict, string fbxAssetPath)
+        private static bool UpdatePrefabMeshReferences(GameObject prefabRoot, string prefabName, MeshFilter[] meshFilters)
         {
-            // Get all sub-assets of type Mesh from the FBX
-            Object[] subAssets = AssetDatabase.LoadAllAssetsAtPath(fbxAssetPath);
+            int updatedCount = 0;
             
-            foreach (var asset in subAssets)
+            foreach (var meshFilter in meshFilters)
             {
-                if (asset is Mesh mesh)
+                if (meshFilter.sharedMesh == null)
+                    continue;
+                    
+                string gameObjectName = meshFilter.gameObject.name;
+                string fbxAssetPath = GetIndividualFBXAssetPath(prefabName, gameObjectName);
+                
+                // Check if the FBX file exists
+                if (!File.Exists(Path.Combine(Application.dataPath, "..", fbxAssetPath)))
                 {
-                    string meshName = mesh.name;
-                    if (!meshDict.ContainsKey(meshName))
+                    LogWarning($"FBX not found for {gameObjectName}, skipping");
+                    continue;
+                }
+                
+                // Load the FBX
+                GameObject fbxObject = AssetDatabase.LoadAssetAtPath<GameObject>(fbxAssetPath);
+                if (fbxObject == null)
+                {
+                    LogWarning($"Failed to load FBX for {gameObjectName}");
+                    continue;
+                }
+                
+                // Get the mesh from the FBX
+                // The FBX should contain the mesh as a sub-asset
+                Object[] subAssets = AssetDatabase.LoadAllAssetsAtPath(fbxAssetPath);
+                Mesh fbxMesh = null;
+                
+                foreach (var asset in subAssets)
+                {
+                    if (asset is Mesh mesh)
                     {
-                        meshDict[meshName] = mesh;
-                        Debug.Log($"[FBXify] Found mesh in FBX: {meshName}");
+                        fbxMesh = mesh;
+                        Log($"Found mesh '{mesh.name}' in {gameObjectName}.fbx");
+                        break;
                     }
+                }
+                
+                if (fbxMesh != null)
+                {
+                    meshFilter.sharedMesh = fbxMesh;
+                    updatedCount++;
+                    Log($"Updated mesh reference: {gameObjectName} -> {fbxMesh.name}");
+                }
+                else
+                {
+                    LogWarning($"No mesh found in FBX for {gameObjectName}");
                 }
             }
             
-            // Also collect meshes from MeshFilters in the FBX GameObject hierarchy
-            MeshFilter[] meshFilters = fbxObject.GetComponentsInChildren<MeshFilter>(true);
-            foreach (var mf in meshFilters)
-            {
-                if (mf.sharedMesh != null)
-                {
-                    string objectName = mf.gameObject.name;
-                    if (!meshDict.ContainsKey(objectName))
-                    {
-                        meshDict[objectName] = mf.sharedMesh;
-                        Debug.Log($"[FBXify] Found mesh via MeshFilter: {objectName} -> {mf.sharedMesh.name}");
-                    }
-                }
-            }
+            Log($"Updated {updatedCount}/{meshFilters.Length} mesh references");
+            return updatedCount > 0;
         }
     }
 }

--- a/CustomMap/Assets/Editor/FBXifyMeshesProcessor.cs
+++ b/CustomMap/Assets/Editor/FBXifyMeshesProcessor.cs
@@ -1,0 +1,204 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Formats.Fbx.Exporter;
+using UnityEngine;
+
+namespace CustomMap.Editor
+{
+    public static class FBXifyMeshesProcessor
+    {
+        public static bool ProcessPrefab(string prefabPath)
+        {
+            // Load the prefab
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            if (prefab == null)
+            {
+                Debug.LogError($"[FBXify] Failed to load prefab: {prefabPath}");
+                return false;
+            }
+            
+            string prefabName = Path.GetFileNameWithoutExtension(prefabPath);
+            string fbxPath = FBXifyMeshes.GetFBXOutputPath(prefabName);
+            
+            // Export to FBX using Unity's FBX Exporter
+            string exportedPath = ModelExporter.ExportObject(fbxPath, prefab);
+            if (string.IsNullOrEmpty(exportedPath))
+            {
+                Debug.LogError($"[FBXify] Failed to export FBX: {prefabName}");
+                return false;
+            }
+            Debug.Log($"[FBXify] Exported FBX to: {exportedPath}");
+            
+            // Import the FBX back into Unity
+            string fbxAssetPath = FBXifyMeshes.GetFBXAssetPath(prefabName);
+            
+            // Force Unity to import the FBX file
+            AssetDatabase.Refresh();
+            AssetDatabase.ImportAsset(fbxAssetPath, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+            
+            // Wait for import to complete
+            AssetDatabase.SaveAssets();
+            
+            // Update mesh references in the original prefab
+            if (!UpdatePrefabMeshReferences(prefabPath, fbxAssetPath))
+            {
+                Debug.LogError($"[FBXify] Failed to update mesh references: {prefabName}");
+                return false;
+            }
+            
+            return true;
+        }
+        
+        private static bool UpdatePrefabMeshReferences(string prefabPath, string fbxAssetPath)
+        {
+            // Ensure the FBX exists in the asset database
+            if (!File.Exists(Path.Combine(Application.dataPath, "..", fbxAssetPath)))
+            {
+                Debug.LogError($"[FBXify] FBX file does not exist at path: {fbxAssetPath}");
+                return false;
+            }
+            
+            // Load the FBX as a model
+            GameObject fbxModel = AssetDatabase.LoadAssetAtPath<GameObject>(fbxAssetPath);
+            if (fbxModel == null)
+            {
+                Debug.LogError($"[FBXify] Failed to load imported FBX: {fbxAssetPath}. Trying to refresh asset database...");
+                AssetDatabase.Refresh();
+                fbxModel = AssetDatabase.LoadAssetAtPath<GameObject>(fbxAssetPath);
+                
+                if (fbxModel == null)
+                {
+                    Debug.LogError($"[FBXify] Still cannot load FBX after refresh: {fbxAssetPath}");
+                    return false;
+                }
+            }
+            
+            // Get all meshes from the FBX
+            var fbxMeshes = new Dictionary<string, Mesh>();
+            CollectMeshesFromFBX(fbxModel, fbxMeshes, fbxAssetPath);
+            
+            // Load and update the prefab
+            GameObject prefabRoot = PrefabUtility.LoadPrefabContents(prefabPath);
+            if (prefabRoot == null)
+            {
+                Debug.LogError($"[FBXify] Failed to load prefab for updating: {prefabPath}");
+                return false;
+            }
+            
+            try
+            {
+                // Update all MeshFilter components in the prefab
+                MeshFilter[] meshFilters = prefabRoot.GetComponentsInChildren<MeshFilter>(true);
+                int updatedCount = 0;
+                
+                // First, let's see what meshes are available
+                if (fbxMeshes.Count == 0)
+                {
+                    Debug.LogWarning($"[FBXify] No meshes found in FBX file!");
+                }
+                else
+                {
+                    Debug.Log($"[FBXify] Found {fbxMeshes.Count} meshes in FBX: {string.Join(", ", fbxMeshes.Keys)}");
+                }
+                
+                foreach (var meshFilter in meshFilters)
+                {
+                    if (meshFilter.sharedMesh != null)
+                    {
+                        string originalMeshName = meshFilter.sharedMesh.name;
+                        string gameObjectName = meshFilter.gameObject.name;
+                        
+                        // Unity's FBX Exporter typically uses the GameObject name for the mesh
+                        // Let's try to find a mesh that matches
+                        Mesh fbxMesh = null;
+                        string matchedName = null;
+                        
+                        // First try exact GameObject name match
+                        if (fbxMeshes.TryGetValue(gameObjectName, out fbxMesh))
+                        {
+                            matchedName = gameObjectName;
+                        }
+                        // If there's only one mesh and we have many MeshFilters, they might all share it
+                        else if (fbxMeshes.Count == 1)
+                        {
+                            var singleMesh = fbxMeshes.First();
+                            fbxMesh = singleMesh.Value;
+                            matchedName = singleMesh.Key;
+                            Debug.Log($"[FBXify] Using single mesh '{matchedName}' for GameObject '{gameObjectName}'");
+                        }
+                        // Try to find any mesh that contains the GameObject name
+                        else
+                        {
+                            foreach (var kvp in fbxMeshes)
+                            {
+                                if (kvp.Key.Contains(gameObjectName) || gameObjectName.Contains(kvp.Key))
+                                {
+                                    fbxMesh = kvp.Value;
+                                    matchedName = kvp.Key;
+                                    break;
+                                }
+                            }
+                        }
+                        
+                        if (fbxMesh != null)
+                        {
+                            meshFilter.sharedMesh = fbxMesh;
+                            updatedCount++;
+                            Debug.Log($"[FBXify] Updated: {gameObjectName} -> {matchedName} (mesh ID: {fbxMesh.GetInstanceID()})");
+                        }
+                        else
+                        {
+                            Debug.LogWarning($"[FBXify] No match for: {gameObjectName} (original: {originalMeshName})");
+                        }
+                    }
+                }
+                
+                // Save the updated prefab
+                PrefabUtility.SaveAsPrefabAsset(prefabRoot, prefabPath);
+                Debug.Log($"[FBXify] Updated {updatedCount} mesh references in prefab: {Path.GetFileNameWithoutExtension(prefabPath)}");
+                
+                return true;
+            }
+            finally
+            {
+                PrefabUtility.UnloadPrefabContents(prefabRoot);
+            }
+        }
+        
+        private static void CollectMeshesFromFBX(GameObject fbxObject, Dictionary<string, Mesh> meshDict, string fbxAssetPath)
+        {
+            // Get all sub-assets of type Mesh from the FBX
+            Object[] subAssets = AssetDatabase.LoadAllAssetsAtPath(fbxAssetPath);
+            
+            foreach (var asset in subAssets)
+            {
+                if (asset is Mesh mesh)
+                {
+                    string meshName = mesh.name;
+                    if (!meshDict.ContainsKey(meshName))
+                    {
+                        meshDict[meshName] = mesh;
+                        Debug.Log($"[FBXify] Found mesh in FBX: {meshName}");
+                    }
+                }
+            }
+            
+            // Also collect meshes from MeshFilters in the FBX GameObject hierarchy
+            MeshFilter[] meshFilters = fbxObject.GetComponentsInChildren<MeshFilter>(true);
+            foreach (var mf in meshFilters)
+            {
+                if (mf.sharedMesh != null)
+                {
+                    string objectName = mf.gameObject.name;
+                    if (!meshDict.ContainsKey(objectName))
+                    {
+                        meshDict[objectName] = mf.sharedMesh;
+                        Debug.Log($"[FBXify] Found mesh via MeshFilter: {objectName} -> {mf.sharedMesh.name}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/CustomMap/Assets/Editor/FBXifyMeshesProcessor.cs
+++ b/CustomMap/Assets/Editor/FBXifyMeshesProcessor.cs
@@ -131,8 +131,7 @@ namespace CustomMap.Editor
                     if (asset is Mesh mesh)
                     {
                         fbxMesh = mesh;
-                        Log($"Found mesh '{mesh.name}' in {gameObjectName}.fbx");
-                        break;
+                            break;
                     }
                 }
                 
@@ -140,7 +139,6 @@ namespace CustomMap.Editor
                 {
                     meshFilter.sharedMesh = fbxMesh;
                     updatedCount++;
-                    Log($"Updated mesh reference: {gameObjectName} -> {fbxMesh.name}");
                 }
                 else
                 {
@@ -148,7 +146,6 @@ namespace CustomMap.Editor
                 }
             }
             
-            Log($"Updated {updatedCount}/{meshFilters.Length} mesh references");
             return updatedCount > 0;
         }
         
@@ -252,30 +249,19 @@ namespace CustomMap.Editor
                 Object[] subAssets = AssetDatabase.LoadAllAssetsAtPath(fbxAssetPath);
                 Mesh fbxMesh = null;
                 
-                Log($"Checking FBX at: {fbxAssetPath}");
-                Log($"Found {subAssets.Length} sub-assets in FBX");
-                
                 foreach (var asset in subAssets)
                 {
                     if (asset is Mesh mesh)
                     {
                         fbxMesh = mesh;
-                        Log($"Found mesh '{mesh.name}' (type: {mesh.GetType().Name}) in {gameObjectName}.fbx");
                         break;
-                    }
-                    else
-                    {
-                        Log($"  Sub-asset: {asset.name} (type: {asset.GetType().Name})");
                     }
                 }
                 
                 if (fbxMesh != null)
                 {
                     // Use Undo for scene objects so changes can be undone
-                    Undo.RecordObject(meshFilter, "FBXify Mesh Reference");
-                    
-                    // Store old mesh for logging
-                    string oldMeshName = meshFilter.sharedMesh != null ? meshFilter.sharedMesh.name : "null";
+                    Undo.RecordObject(meshFilter, $"{FBXifyMeshes.TOOL_NAME} Mesh Reference");
                     
                     // Update the mesh reference
                     meshFilter.sharedMesh = fbxMesh;
@@ -285,7 +271,6 @@ namespace CustomMap.Editor
                     EditorUtility.SetDirty(meshFilter.gameObject);
                     
                     updatedCount++;
-                    Log($"Updated mesh reference: {gameObjectName} from '{oldMeshName}' -> '{fbxMesh.name}'");
                 }
                 else
                 {
@@ -293,7 +278,6 @@ namespace CustomMap.Editor
                 }
             }
             
-            Log($"Updated {updatedCount}/{meshFilters.Length} mesh references");
             return updatedCount > 0;
         }
     }

--- a/CustomMap/Assets/Editor/FBXifyMeshesProcessor.cs.meta
+++ b/CustomMap/Assets/Editor/FBXifyMeshesProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eeca31dcc4ca940bcaeb5f9c65447144
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Potentially a temporary tool, until another workaround can be found.

https://github.com/user-attachments/assets/fbb8566e-38d4-490d-afa1-684efdc2d179

Targetting a prefab, this tool runs the FBX exporter on every GameObject that has at least one meshfilter,  exports an FBX, and then retargets the mesh filter to use the FBX.

How to use:
1. In the Project window, select a prefab to convert
2. Gatekeeper -> FBXify Meshes -> Process selected prefab

Assumptions made:
Assumes that each mesh is only used by one prefab.
If two prefabs share a mesh, that mesh will be duplicated.

Possible alternatives:
1. I was also able to get it to work exporting one FBX for an entire prefab, with a bunch of submeshes.
But seeing as how each of the mesh filters is a separate concept, I went with this approach.

2. A tool that achieves similar results could work in reverse, and first exporting everything in the mesh folder to FBX, and then updating its dependents.




